### PR TITLE
Adding an initial version of reusable workflow for chainloop.

### DIFF
--- a/.github/workflows/chainloop.yml
+++ b/.github/workflows/chainloop.yml
@@ -6,7 +6,7 @@ on:
         required: false
         type: string
     secrets:
-      token:
+      api_token:
         required: true
       signing_key:
         required: true
@@ -80,5 +80,5 @@ jobs:
 
     env:
       CHAINLOOP_VERSION: ${{ inputs.chainloop_version }}
-      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.token }}
+      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.api_token }}
       


### PR DESCRIPTION
This is how the workflow is going to be used:

```
  chainloop:
    uses: chainloop-dev/labs/.github/workflows/chainloop.yml@main
    needs: validate-and-generate-reports
    secrets:
      token: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT }}
      signing_key: ${{ secrets.COSIGN_PRIVATE_KEY }}
      signing_key_password: ${{ secrets.COSIGN_PASSWORD }}
```

You will need to use upload-artifact action to share all metadata which you want to store in Chainloop. 

```
      - uses: actions/upload-artifact@v3
        with:
          name: reports
          path: reports/*
```

Finally we expect the `.chainloop/config.yml` config file to provide information about metadata files to be stored. Example:

```
attestation:
  - name: sbom-cdx
    path: reports/sbom.cyclonedx.json
  - name: sbom-spdx
    path: reports/sbom.spdx.json
  - name: built-site
    path: reports/build.tar.gz
```