### PR TITLE
fix(ci-ini): First checkout the pull CLI

### DIFF
--- a/.github/workflows/chainloop_init.yml
+++ b/.github/workflows/chainloop_init.yml
@@ -22,17 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - name: Install Chainloop CLI, Labs and Cosign
-        run: |
-          curl -sfL https://raw.githubusercontent.com/chainloop-dev/labs/${{ inputs.chainloop_labs_branch }}/tools/install_c8l.sh | bash -s -- ${{ inputs.chainloop_labs_branch }} chainloop_cli cosign
-          source <(/usr/local/bin/chainloop/c8l source)
-
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           sparse-checkout: |
             .git
+
+      - name: Install Chainloop CLI, Labs and Cosign
+        run: |
+          curl -sfL https://raw.githubusercontent.com/chainloop-dev/labs/${{ inputs.chainloop_labs_branch }}/tools/install_c8l.sh | bash -s -- ${{ inputs.chainloop_labs_branch }} chainloop_cli cosign
+          source <(/usr/local/bin/chainloop/c8l source)
 
       - name: Initialize Attestation
         run: |


### PR DESCRIPTION
This PR moves the checkout of the repo before the pull of the chainloop CLI to try to avoid overrides.