### PR TITLE
fix(push): pass attestation id on failure

### DIFF
--- a/.github/workflows/chainloop_push.yml
+++ b/.github/workflows/chainloop_push.yml
@@ -85,13 +85,13 @@ jobs:
         if: ${{ failure() }}
         run: |
           source <(/usr/local/bin/chainloop/c8l source)
-          chainloop attestation reset
+          chainloop attestation reset --attestation-id ${CHAINLOOP_ATTESTATION_ID}
           chainloop_generate_github_summary_on_failure
           
       - name: Mark attestation as cancelled
         if: ${{ cancelled() }}
         run: |
-          chainloop attestation reset --trigger cancellation
+          chainloop attestation reset --trigger cancellation --attestation-id ${CHAINLOOP_ATTESTATION_ID}
 
     env:
       CHAINLOOP_VERSION: ${{ inputs.chainloop_version }}


### PR DESCRIPTION
This PR passes the attestation ID to the steps failed and cancelled to reset the state.