### PR TITLE
feat(onboarding): reusable workflow for automated onboarding

### DIFF
--- a/.github/workflows/chainloop_onboard.yml
+++ b/.github/workflows/chainloop_onboard.yml
@@ -1,0 +1,49 @@
+on:
+  workflow_call:
+    inputs:
+      project:
+        description: The chainloop project, usually matching a project or team within the organization
+        type: string
+        required: true
+      workflow_name:
+        description: The workflow name. It will use the parent github workflow file name if not provided.
+        type: string
+    secrets:
+      api_token:
+        required: true
+    outputs:
+      workflow_name:
+        description: The discovered or created Chainloop workflow
+        value: ${{ jobs.chainloop_onboard.outputs.workflow_name }}
+
+jobs:
+  chainloop_onboard:
+    name: Automatic Chainloop onboarding flow from Github Actions
+    runs-on: ubuntu-latest
+    outputs:
+      workflow_name: ${{ steps.set_workflow_name.outputs.workflow_name }}
+
+    steps:
+      - name: Install Chainloop
+        run: |
+          curl -sfL https://docs.chainloop.dev/install.sh | bash -s
+
+      - id: set_workflow_name
+        name: Set workflow name
+        env:
+          # contains full path to the parent workflow (.github/workflows/parent_workflow.yml)
+          PARENT_WORKFLOW: ${{ github.workflow }}
+        run: |
+          workflow_name=${{ inputs.workflow_name }}
+          if [[ "$workflow_name" = "" ]]; then
+            workflow_name=$(basename "$PARENT_WORKFLOW" | sed "s/\..*$//g")
+          fi
+          echo "workflow_name=$workflow_name" >> $GITHUB_OUTPUT
+
+      - name: Discover and create workflow
+        env:
+          WORKFLOW_NAME: ${{ steps.set_workflow_name.outputs.workflow_name }}
+        run: |
+          echo "Creating '$WORKFLOW_NAME' chainloop workflow" 
+          chainloop --token ${{ secrets.api_token }} wf describe --name "$WORKFLOW_NAME" || \
+            chainloop --token ${{ secrets.api_token }} wf create --name "$WORKFLOW_NAME" --project "${{ inputs.project }}"

--- a/.github/workflows/chainloop_onboard.yml
+++ b/.github/workflows/chainloop_onboard.yml
@@ -2,14 +2,15 @@ on:
   workflow_call:
     inputs:
       project:
-        description: The chainloop project, usually matching a project or team within the organization
+        description: The project this workflow belongs to.
         type: string
         required: true
       workflow_name:
-        description: The workflow name. It will use the parent github workflow file name if not provided.
+        description: "The workflow name. default: parent workflow filename"
         type: string
     secrets:
       api_token:
+        description: "Reference: https://docs.chainloop.dev/reference/operator/api-tokens#api-tokens"
         required: true
     outputs:
       workflow_name:
@@ -44,6 +45,5 @@ jobs:
         env:
           WORKFLOW_NAME: ${{ steps.set_workflow_name.outputs.workflow_name }}
         run: |
-          echo "Creating '$WORKFLOW_NAME' chainloop workflow" 
-          chainloop --token ${{ secrets.api_token }} wf describe --name "$WORKFLOW_NAME" || \
-            chainloop --token ${{ secrets.api_token }} wf create --name "$WORKFLOW_NAME" --project "${{ inputs.project }}"
+          echo "Creating '$WORKFLOW_NAME' chainloop workflow"
+          chainloop --token ${{ secrets.api_token }} wf create --name "$WORKFLOW_NAME" --project "${{ inputs.project }}" >&2 || echo -n "Workflow already exists"

--- a/.github/workflows/chainloop_onboard.yml
+++ b/.github/workflows/chainloop_onboard.yml
@@ -2,9 +2,8 @@ on:
   workflow_call:
     inputs:
       project:
-        description: The project this workflow belongs to.
+        description: "The project this workflow belongs to. default: repository name"
         type: string
-        required: true
       workflow_name:
         description: "The workflow name. default: parent workflow filename"
         type: string
@@ -46,4 +45,8 @@ jobs:
           WORKFLOW_NAME: ${{ steps.set_workflow_name.outputs.workflow_name }}
         run: |
           echo "Creating '$WORKFLOW_NAME' chainloop workflow"
-          chainloop --token ${{ secrets.api_token }} wf create --name "$WORKFLOW_NAME" --project "${{ inputs.project }}" >&2 || echo -n "Workflow already exists"
+          project=${{ inputs.project }}
+          if [[ "$project" = "" ]]; then
+            project=$(echo -n ${{github.repositoryUrl}} | rev | cut -d'/' -f1 | rev | sed 's/.git$//g')
+          fi
+          chainloop --token ${{ secrets.api_token }} wf create --name "$WORKFLOW_NAME" --project "$project" >&2 || echo -n "Workflow already exists"


### PR DESCRIPTION
This a reusable workflow that uses the latest improvements on API_TOKENs to automatically onboard a GH job in Chainloop.
It needs a `project` parameter, and accepts a `workflow_name` as input, and, if missing, it will use the github action file name as the workflow name. 

Usage:
file .github/workflows/my_workflow.yml
```
jobs:
  onboard:
    uses: ./.github/workflows/chainloop_onboard.yml
    with:
      project: my-team
    secrets:
      api_token: ${{ secrets.CHAINLOOP_API_TOKEN }}
```

As a result, it will create a Chainloop workflow called `my_workflow` with the default contract.