### PR TITLE
feat(cli): remove att status in reusable workflow

### DIFF
--- a/.github/workflows/chainloop_push.yml
+++ b/.github/workflows/chainloop_push.yml
@@ -62,11 +62,6 @@ jobs:
           source <(/usr/local/bin/chainloop/c8l source)
           chainloop_attestation_add_from_yaml ${{ inputs.attestation_name }}
  
-      - name: Chainloop Attestation Status
-        run: |
-          source <(/usr/local/bin/chainloop/c8l source)
-          chainloop_attestation_status
- 
       - name: Validate Collected Artifacts and Record Attestation
         if: ${{ success() }}
         run: |


### PR DESCRIPTION
Since a recent release, the content shown in this command is already rendered in the push command. This PR removes the duplicity.

refs chainloop-dev/chainloop#750