### PR TITLE
Replace CHAINLOOP_API_TOKEN by CHAINLOOP_TOKEN

### DIFF
--- a/.github/workflows/chainloop_contract_sync.yml
+++ b/.github/workflows/chainloop_contract_sync.yml
@@ -40,4 +40,4 @@ jobs:
 
     env:
       CHAINLOOP_VERSION: ${{ inputs.chainloop_version }}
-      CHAINLOOP_API_TOKEN: ${{ secrets.api_token }}
+      CHAINLOOP_TOKEN: ${{ secrets.api_token }}


### PR DESCRIPTION
This patch changes the old env variable in favor of the new one on the reusable workflow.