### PR TITLE
feat(github_release): Graceful error when no enough permissions

### DIFF
--- a/.github/workflows/chainloop_github_release.yml
+++ b/.github/workflows/chainloop_github_release.yml
@@ -2,6 +2,8 @@
 # It uses the Chainloop CLI to create an attestation for the release assets, source code and additional materials if provided.
 # The attestation is then pushed to the Chainloop service and the attestation link is added to the release notes.
 # Prior to running this workflow, the Chainloop workflow is onboarded if it does not exist.
+# By default, the permission is contents:read to download the release assets. If you want the release notes
+# to be updated with the attestation link, modify it to contents:write.
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/chainloop_github_release.yml
+++ b/.github/workflows/chainloop_github_release.yml
@@ -25,10 +25,6 @@ on:
         description: "The password for the private key used to sign the attestation"
         required: true
 
-# Write permissions on contents since we are updating the release notes
-permissions:
-  contents: write
-
 jobs:
   onboard_workflow:
     name: Onboard Chainloop Workflow
@@ -118,4 +114,5 @@ jobs:
             modified_notes="$chainloop_release_url"$'\n\n'"$current_notes"
           fi
 
-          gh release edit ${{github.ref_name}} -n "$modified_notes"
+          # Try to update the release notes with the attestation link. If we don't have enough permissions, we skip it
+          gh release edit ${{github.ref_name}} -n "$modified_notes" || echo -n "No enough permissions to update the release notes. Skipping..."


### PR DESCRIPTION
This patch avoids failure when the permissions are not enough to modify an existing release. 

- Removes the default `contents:write` permission since it's not transparent for end users.
- Updates the description to state the needed permission to modify the release notes is `contents:write`

Closes https://github.com/chainloop-dev/chainloop/issues/852