### PR TITLE
feat(workflows-labs): Consolidates robot accounts into API token

### DIFF
--- a/.github/workflows/chainloop.yml
+++ b/.github/workflows/chainloop.yml
@@ -100,6 +100,6 @@ jobs:
 
     env:
       CHAINLOOP_VERSION: ${{ inputs.chainloop_version }}
-      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.api_token }}
+      CHAINLOOP_TOKEN: ${{ secrets.api_token }}
       CHAINLOOP_CONTRACT_REVISION: ${{ inputs.contract_revision }}
       

--- a/.github/workflows/chainloop_init.yml
+++ b/.github/workflows/chainloop_init.yml
@@ -49,5 +49,5 @@ jobs:
 
     env:
       CHAINLOOP_VERSION: ${{ inputs.chainloop_version }}
-      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.api_token }}
+      CHAINLOOP_TOKEN: ${{ secrets.api_token }}
       CHAINLOOP_CONTRACT_REVISION: ${{ inputs.contract_revision }}

--- a/.github/workflows/chainloop_push.yml
+++ b/.github/workflows/chainloop_push.yml
@@ -90,6 +90,6 @@ jobs:
 
     env:
       CHAINLOOP_VERSION: ${{ inputs.chainloop_version }}
-      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.api_token }}
+      CHAINLOOP_TOKEN: ${{ secrets.api_token }}
       CHAINLOOP_CONTRACT_REVISION: ${{ inputs.contract_revision }}
       


### PR DESCRIPTION
This patch removes the usage of Robot Accounts from reusable workflows in order to use `CHAINLOOP_TOKEN` or API tokens.

