### PR TITLE
feat(c8l): Update c8l to allow workflow-names on attestations

### DIFF
--- a/.github/workflows/chainloop.yml
+++ b/.github/workflows/chainloop.yml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
         default: main
+      workflow_name:
+        required: false
+        type: string
     secrets:
       api_token:
         required: true
@@ -102,4 +105,4 @@ jobs:
       CHAINLOOP_VERSION: ${{ inputs.chainloop_version }}
       CHAINLOOP_TOKEN: ${{ secrets.api_token }}
       CHAINLOOP_CONTRACT_REVISION: ${{ inputs.contract_revision }}
-      
+      CHAINLOOP_WORKFLOW_NAME: ${{ inputs.workflow_name }}

--- a/.github/workflows/chainloop_init.yml
+++ b/.github/workflows/chainloop_init.yml
@@ -12,6 +12,9 @@ on:
         required: false
         type: string
         default: main
+      workflow_name:
+        required: false
+        type: string
     secrets:
       api_token:
         required: true
@@ -51,3 +54,4 @@ jobs:
       CHAINLOOP_VERSION: ${{ inputs.chainloop_version }}
       CHAINLOOP_TOKEN: ${{ secrets.api_token }}
       CHAINLOOP_CONTRACT_REVISION: ${{ inputs.contract_revision }}
+      CHAINLOOP_WORKFLOW_NAME: ${{ inputs.workflow_name }}

--- a/.github/workflows/chainloop_push.yml
+++ b/.github/workflows/chainloop_push.yml
@@ -12,6 +12,9 @@ on:
         required: false
         type: string
         default: main
+      workflow_name:
+        required: false
+        type: string
     secrets:
       api_token:
         required: true
@@ -92,4 +95,5 @@ jobs:
       CHAINLOOP_VERSION: ${{ inputs.chainloop_version }}
       CHAINLOOP_TOKEN: ${{ secrets.api_token }}
       CHAINLOOP_CONTRACT_REVISION: ${{ inputs.contract_revision }}
+      CHAINLOOP_WORKFLOW_NAME: ${{ inputs.workflow_name }}
       

--- a/tools/c8l
+++ b/tools/c8l
@@ -803,7 +803,11 @@ chainloop_attestation_init() {
   if [ -n "${CHAINLOOP_CONTRACT_REVISION}" ]; then
     CR_VALUE="--contract-revision ${CHAINLOOP_CONTRACT_REVISION}"
   fi
-  r=$(chainloop attestation init -f --remote-state --output json $CR_VALUE)
+  WF_VALUE=""
+  if [ -n "${CHAINLOOP_WORKFLOW_NAME}" ]; then
+    WF_VALUE="--workflow-name ${CHAINLOOP_WORKFLOW_NAME}"
+  fi
+  r=$(chainloop attestation init -f --remote-state --output json $CR_VALUE $WF_VALUE)
   if [ $? -ne 0 ]; then
     log_error "Chainloop initialization failed: $r"
     return 1

--- a/tools/c8l
+++ b/tools/c8l
@@ -803,11 +803,11 @@ chainloop_attestation_init() {
   if [ -n "${CHAINLOOP_CONTRACT_REVISION}" ]; then
     CR_VALUE="--contract-revision ${CHAINLOOP_CONTRACT_REVISION}"
   fi
-  WF_VALUE=""
+  WF_NAME_VALUE=""
   if [ -n "${CHAINLOOP_WORKFLOW_NAME}" ]; then
-    WF_VALUE="--workflow-name ${CHAINLOOP_WORKFLOW_NAME}"
+    WF_NAME_VALUE="--workflow-name ${CHAINLOOP_WORKFLOW_NAME}"
   fi
-  r=$(chainloop attestation init -f --remote-state --output json $CR_VALUE $WF_VALUE)
+  r=$(chainloop attestation init -f --remote-state --output json $CR_VALUE $WF_NAME_VALUE)
   if [ $? -ne 0 ]; then
     log_error "Chainloop initialization failed: $r"
     return 1

--- a/tools/src/lib/chainloop.sh
+++ b/tools/src/lib/chainloop.sh
@@ -108,7 +108,11 @@ chainloop_attestation_init() {
   if [ -n "${CHAINLOOP_CONTRACT_REVISION}" ]; then
     CR_VALUE="--contract-revision ${CHAINLOOP_CONTRACT_REVISION}"
   fi
-  r=$(chainloop attestation init -f --remote-state --output json $CR_VALUE)
+  WF_NAME_VALUE=""
+  if [ -n "${CHAINLOOP_WORKFLOW_NAME}" ]; then
+    WF_NAME_VALUE="--workflow-name ${CHAINLOOP_WORKFLOW_NAME}"
+  fi
+  r=$(chainloop attestation init -f --remote-state --output json $CR_VALUE $WF_NAME_VALUE)
   if [ $? -ne 0 ]; then
     log_error "Chainloop initialization failed: $r"
     return 1


### PR DESCRIPTION
This patch updates three reusable workflows and the internal generated bash script to allow `--workflow-name` to be passed down to the CLI.

It does so by establishing a env with the value received from the input.

This PR will unlock https://github.com/chainloop-dev/chainloop/pull/876, which will need to update its reference.