### PR TITLE
Fix c8l library for att push

### DIFF
--- a/tools/c8l
+++ b/tools/c8l
@@ -856,6 +856,8 @@ chainloop_summary() {
     digest=$(cat c8-push.txt | grep " Digest: " | awk -F'sha256:'  '{print $2}')
     echo "**[Chainloop Trust Report]( https://app.chainloop.dev/attestation/sha256:${digest} )**" >>$tmpfile
     echo "\`\`\`" >>$tmpfile
+  fi
+  if [ -f c8-status.txt ]; then
     cat c8-status.txt >>$tmpfile
     echo "\`\`\`" >>$tmpfile
   fi

--- a/tools/src/lib/chainloop.sh
+++ b/tools/src/lib/chainloop.sh
@@ -161,6 +161,8 @@ chainloop_summary() {
     digest=$(cat c8-push.txt | grep " Digest: " | awk -F'sha256:'  '{print $2}')
     echo "**[Chainloop Trust Report]( https://app.chainloop.dev/attestation/sha256:${digest} )**" >>$tmpfile
     echo "\`\`\`" >>$tmpfile
+  fi
+  if [ -f c8-status.txt ]; then
     cat c8-status.txt >>$tmpfile
     echo "\`\`\`" >>$tmpfile
   fi


### PR DESCRIPTION
Fixes a small bug due to the lack of `att status` in some workflows.

Refs chainloop-dev/chainloop#750