### PR TITLE
chore: update scripts to initialize with project_name

### DIFF
--- a/.github/workflows/chainloop.yml
+++ b/.github/workflows/chainloop.yml
@@ -18,6 +18,9 @@ on:
       workflow_name:
         required: false
         type: string
+      project_name:
+        required: false
+        type: string
     secrets:
       api_token:
         required: true
@@ -25,12 +28,12 @@ on:
         required: true
       signing_key_password:
         required: true
-    
+
 jobs:
   chainloop-attestation:
     name: Chainloop Attestation Process
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,12 +72,12 @@ jobs:
         run: |
           source <(/usr/local/bin/chainloop/c8l source)
           chainloop_attestation_add_from_yaml ${{ inputs.attestation_name }}
- 
+
       - name: Chainloop Attestation Status
         run: |
           source <(/usr/local/bin/chainloop/c8l source)
           chainloop_attestation_status
- 
+
       - name: Validate Collected Artifacts and Record Attestation
         if: ${{ success() }}
         run: |
@@ -83,7 +86,7 @@ jobs:
         env:
           CHAINLOOP_SIGNING_KEY: ${{ secrets.signing_key }}
           CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.signing_key_password }}
-  
+
       - name: Generate a summary report
         run: |
           source <(/usr/local/bin/chainloop/c8l source)
@@ -95,7 +98,7 @@ jobs:
           source <(/usr/local/bin/chainloop/c8l source)
           chainloop attestation reset
           chainloop_generate_github_summary_on_failure
-          
+
       - name: Mark attestation as cancelled
         if: ${{ cancelled() }}
         run: |
@@ -106,3 +109,4 @@ jobs:
       CHAINLOOP_TOKEN: ${{ secrets.api_token }}
       CHAINLOOP_CONTRACT_REVISION: ${{ inputs.contract_revision }}
       CHAINLOOP_WORKFLOW_NAME: ${{ inputs.workflow_name }}
+      CHAINLOOP_PROJECT_NAME: ${{ inputs.project_name }}

--- a/.github/workflows/chainloop_github_release.yml
+++ b/.github/workflows/chainloop_github_release.yml
@@ -30,10 +30,10 @@ on:
 jobs:
   onboard_workflow:
     name: Onboard Chainloop Workflow
-    uses: chainloop-dev/labs/.github/workflows/chainloop_onboard.yml@4173e015dbd5dc2a8802555c268da63d57bbe576
+    uses: chainloop-dev/labs/.github/workflows/chainloop_onboard.yml@main
     if: github.event_name == 'release' && github.event.action == 'published'
     with:
-      project: ${{ inputs.workflow_project }}
+      project: ${{ inputs.project }}
       workflow_name: ${{ inputs.workflow_name }}
     # Pass parent workflow secrets to the child workflow
     secrets: inherit
@@ -46,6 +46,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     env:
       CHAINLOOP_WORKFLOW_NAME: ${{ needs.onboard_workflow.outputs.workflow_name }}
+      CHAINLOOP_PROJECT_NAME: ${{ needs.onboard_workflow.outputs.project_name }}
       CHAINLOOP_TOKEN: ${{ secrets.api_token }}
       GH_TOKEN: ${{ github.token }}
 
@@ -58,14 +59,14 @@ jobs:
 
       - name: Initialize Attestation
         run: |
-          chainloop attestation init --workflow-name ${CHAINLOOP_WORKFLOW_NAME}
+          chainloop attestation init --workflow-name ${CHAINLOOP_WORKFLOW_NAME} --project ${CHAINLOOP_PROJECT_NAME}
 
       - name: Attest all assets
         run: |
           # gh release download raises an error if there are not assets on the release
           # that makes the workflow fail, so we use `|| true` to avoid that
           gh release download ${{github.ref_name}} -D /tmp/github-release || true
-          
+
           for entry in $(ls /tmp/github-release); do
             chainloop attestation add --value "/tmp/github-release/$entry"
           done

--- a/.github/workflows/chainloop_init.yml
+++ b/.github/workflows/chainloop_init.yml
@@ -15,6 +15,9 @@ on:
       workflow_name:
         required: false
         type: string
+      project_name:
+        required: false
+        type: string
     secrets:
       api_token:
         required: true
@@ -23,7 +26,7 @@ jobs:
   chainloop-init:
     name: Chainloop Install & Attestation Init
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -48,10 +51,11 @@ jobs:
         id: cache-chainloop
         with:
           path: .c8l_cache
-          key: c8l-cache-${{ runner.os }}-${{ github.run_id }} 
+          key: c8l-cache-${{ runner.os }}-${{ github.run_id }}
 
     env:
       CHAINLOOP_VERSION: ${{ inputs.chainloop_version }}
       CHAINLOOP_TOKEN: ${{ secrets.api_token }}
       CHAINLOOP_CONTRACT_REVISION: ${{ inputs.contract_revision }}
       CHAINLOOP_WORKFLOW_NAME: ${{ inputs.workflow_name }}
+      CHAINLOOP_PROJECT_NAME: ${{ inputs.project_name }}

--- a/.github/workflows/chainloop_onboard.yml
+++ b/.github/workflows/chainloop_onboard.yml
@@ -15,6 +15,9 @@ on:
       workflow_name:
         description: The discovered or created Chainloop workflow
         value: ${{ jobs.chainloop_onboard.outputs.workflow_name }}
+      project_name:
+        description: The discovered or created Chainloop project name
+        value: ${{ jobs.chainloop_onboard.outputs.project_name }}
 
 jobs:
   chainloop_onboard:
@@ -22,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       workflow_name: ${{ steps.set_workflow_name.outputs.workflow_name }}
+      project_name: ${{ steps.set_workflow_name.outputs.project_name }}
 
     steps:
       - name: Install Chainloop
@@ -40,14 +44,16 @@ jobs:
             workflow_name=$(basename "$PARENT_WORKFLOW" | sed 's/\..*$//g; s/[[:space:]]/-/g; s/_/-/g' | tr '[:upper:]' '[:lower:]')
           fi
           echo "workflow_name=$workflow_name" >> $GITHUB_OUTPUT
-
-      - name: Discover and create workflow
-        env:
-          WORKFLOW_NAME: ${{ steps.set_workflow_name.outputs.workflow_name }}
-        run: |
-          echo "Creating '$WORKFLOW_NAME' chainloop workflow"
           project=${{ inputs.project }}
           if [[ "$project" = "" ]]; then
             project=$(echo -n ${{github.repositoryUrl}} | rev | cut -d'/' -f1 | rev | sed 's/.git$//g')
           fi
-          chainloop --token ${{ secrets.api_token }} wf create --name "$WORKFLOW_NAME" --project "$project" --skip-if-exists
+          echo "project_name=$project" >> $GITHUB_OUTPUT
+
+      - name: Discover and create workflow
+        env:
+          WORKFLOW_NAME: ${{ steps.set_workflow_name.outputs.workflow_name }}
+          PROJECT_NAME: ${{ steps.set_workflow_name.outputs.project_name }}
+        run: |
+          echo "Creating '$PROJECT_NAME' / '$WORKFLOW_NAME' workflow"
+          chainloop --token ${{ secrets.api_token }} wf create --name "$WORKFLOW_NAME" --project "$PROJECT_NAME" --skip-if-exists

--- a/.github/workflows/chainloop_push.yml
+++ b/.github/workflows/chainloop_push.yml
@@ -22,7 +22,7 @@ on:
         required: false
       signing_key_password:
         required: false
-    
+
 jobs:
   chainloop-attestation:
     name: Chainloop Attestation Process
@@ -33,7 +33,7 @@ jobs:
         id: cache-chainloop
         with:
           path: .c8l_cache
-          key: c8l-cache-${{ runner.os }}-${{ github.run_id }} 
+          key: c8l-cache-${{ runner.os }}-${{ github.run_id }}
 
       - name: Restore Chainloop binaries from cache
         run: |
@@ -64,7 +64,7 @@ jobs:
         run: |
           source <(/usr/local/bin/chainloop/c8l source)
           chainloop_attestation_add_from_yaml ${{ inputs.attestation_name }}
- 
+
       - name: Validate Collected Artifacts and Record Attestation
         if: ${{ success() }}
         run: |
@@ -73,7 +73,7 @@ jobs:
         env:
           CHAINLOOP_SIGNING_KEY: ${{ secrets.signing_key }}
           CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.signing_key_password }}
-  
+
       - name: Generate a summary report
         run: |
           source <(/usr/local/bin/chainloop/c8l source)
@@ -85,7 +85,7 @@ jobs:
           source <(/usr/local/bin/chainloop/c8l source)
           chainloop attestation reset --remote-state --attestation-id ${CHAINLOOP_ATTESTATION_ID}
           chainloop_generate_github_summary_on_failure
-          
+
       - name: Mark attestation as cancelled
         if: ${{ cancelled() }}
         run: |
@@ -95,5 +95,5 @@ jobs:
       CHAINLOOP_VERSION: ${{ inputs.chainloop_version }}
       CHAINLOOP_TOKEN: ${{ secrets.api_token }}
       CHAINLOOP_CONTRACT_REVISION: ${{ inputs.contract_revision }}
+      # Not sure if this is being used.
       CHAINLOOP_WORKFLOW_NAME: ${{ inputs.workflow_name }}
-      

--- a/tools/c8l
+++ b/tools/c8l
@@ -676,7 +676,11 @@ chainloop_attestation_init() {
   if [ -n "${CHAINLOOP_WORKFLOW_NAME}" ]; then
     WF_NAME_VALUE="--workflow-name ${CHAINLOOP_WORKFLOW_NAME}"
   fi
-  r=$(chainloop attestation init -f --remote-state --output json $CR_VALUE $WF_NAME_VALUE)
+  PROJECT_NAME_VALUE=""
+  if [ -n "${CHAINLOOP_PROJECT_NAME}" ]; then
+    PROJECT_NAME_VALUE="--project ${CHAINLOOP_PROJECT_NAME}"
+  fi
+  r=$(chainloop attestation init -f --remote-state --output json $CR_VALUE $WF_NAME_VALUE $PROJECT_NAME_VALUE)
   if [ $? -ne 0 ]; then
     log_error "Chainloop initialization failed: $r"
     return 1

--- a/tools/c8l
+++ b/tools/c8l
@@ -674,7 +674,7 @@ chainloop_attestation_init() {
   fi
   WF_NAME_VALUE=""
   if [ -n "${CHAINLOOP_WORKFLOW_NAME}" ]; then
-    WF_NAME_VALUE="--workflow-name ${CHAINLOOP_WORKFLOW_NAME}"
+    WF_NAME_VALUE="--workflow ${CHAINLOOP_WORKFLOW_NAME}"
   fi
   PROJECT_NAME_VALUE=""
   if [ -n "${CHAINLOOP_PROJECT_NAME}" ]; then

--- a/tools/src/lib/chainloop.sh
+++ b/tools/src/lib/chainloop.sh
@@ -95,7 +95,11 @@ chainloop_attestation_init() {
   if [ -n "${CHAINLOOP_WORKFLOW_NAME}" ]; then
     WF_NAME_VALUE="--workflow-name ${CHAINLOOP_WORKFLOW_NAME}"
   fi
-  r=$(chainloop attestation init -f --remote-state --output json $CR_VALUE $WF_NAME_VALUE)
+  PROJECT_NAME_VALUE=""
+  if [ -n "${CHAINLOOP_PROJECT_NAME}" ]; then
+    PROJECT_NAME_VALUE="--project ${CHAINLOOP_PROJECT_NAME}"
+  fi
+  r=$(chainloop attestation init -f --remote-state --output json $CR_VALUE $WF_NAME_VALUE $PROJECT_NAME_VALUE)
   if [ $? -ne 0 ]; then
     log_error "Chainloop initialization failed: $r"
     return 1

--- a/tools/src/lib/chainloop.sh
+++ b/tools/src/lib/chainloop.sh
@@ -93,7 +93,7 @@ chainloop_attestation_init() {
   fi
   WF_NAME_VALUE=""
   if [ -n "${CHAINLOOP_WORKFLOW_NAME}" ]; then
-    WF_NAME_VALUE="--workflow-name ${CHAINLOOP_WORKFLOW_NAME}"
+    WF_NAME_VALUE="--workflow ${CHAINLOOP_WORKFLOW_NAME}"
   fi
   PROJECT_NAME_VALUE=""
   if [ -n "${CHAINLOOP_PROJECT_NAME}" ]; then


### PR DESCRIPTION
Update labs code to get ready for this change https://github.com/chainloop-dev/chainloop/issues/1375

It adds the requirement of doing `att init` indicating the project name. 

Note that I also updated the onboarding project to return the project name too. 

