### PR TITLE
chore(install.sh): Replace URL to download install.sh

### DIFF
--- a/.github/workflows/chainloop_contract_sync.yml
+++ b/.github/workflows/chainloop_contract_sync.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Install Chainloop
         run: |
-          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13af08950b7bfbc83569bea207aeb4e1a285/docs/static/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
+          curl -sfL https://docs.chainloop.dev/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
 
       - name: Checkout repository
         uses: actions/checkout@v4.1.4

--- a/tools/c8l
+++ b/tools/c8l
@@ -617,7 +617,7 @@ chainloop_bin_install() {
 install_chainloop_cli() {
   mkdir -p ${CHAINLOOP_TMP_DIR} $CHAINLOOP_BIN_PATH
   log "Installing Chainloop CLI"
-  url_chainloop_cli="https://gist.githubusercontent.com/javirln/01cfcb36f00668ad1af9e5c02acd1397/raw/f8a271180ed8e5a307fd6c6f2bfbf18c9f30b916/install.sh"
+  url_chainloop_cli="https://docs.chainloop.dev/install.sh"
   if [ -n "${CHAINLOOP_VERSION}" ]; then
     curl -sfL "${url_chainloop_cli}" | bash -s -- --version v${CHAINLOOP_VERSION} --path $CHAINLOOP_BIN_PATH
   else

--- a/tools/c8l
+++ b/tools/c8l
@@ -617,7 +617,7 @@ chainloop_bin_install() {
 install_chainloop_cli() {
   mkdir -p ${CHAINLOOP_TMP_DIR} $CHAINLOOP_BIN_PATH
   log "Installing Chainloop CLI"
-  url_chainloop_cli="https://raw.githubusercontent.com/chainloop-dev/chainloop/eb53f4e8ce3c35251553efc77b7e04e792b2c992/docs/static/install.sh"
+  url_chainloop_cli="https://docs.chainloop.dev/install.sh"
   if [ -n "${CHAINLOOP_VERSION}" ]; then
     curl -sfL "${url_chainloop_cli}" | bash -s -- --version v${CHAINLOOP_VERSION} --path $CHAINLOOP_BIN_PATH
   else

--- a/tools/c8l
+++ b/tools/c8l
@@ -617,7 +617,7 @@ chainloop_bin_install() {
 install_chainloop_cli() {
   mkdir -p ${CHAINLOOP_TMP_DIR} $CHAINLOOP_BIN_PATH
   log "Installing Chainloop CLI"
-  url_chainloop_cli="https://docs.chainloop.dev/install.sh"
+  url_chainloop_cli="https://gist.githubusercontent.com/javirln/01cfcb36f00668ad1af9e5c02acd1397/raw/f8a271180ed8e5a307fd6c6f2bfbf18c9f30b916/install.sh"
   if [ -n "${CHAINLOOP_VERSION}" ]; then
     curl -sfL "${url_chainloop_cli}" | bash -s -- --version v${CHAINLOOP_VERSION} --path $CHAINLOOP_BIN_PATH
   else

--- a/tools/src/lib/chainloop.sh
+++ b/tools/src/lib/chainloop.sh
@@ -33,7 +33,7 @@ chainloop_bin_install() {
 install_chainloop_cli() {
   mkdir -p ${CHAINLOOP_TMP_DIR} $CHAINLOOP_BIN_PATH
   log "Installing Chainloop CLI"
-  url_chainloop_cli="https://gist.githubusercontent.com/javirln/01cfcb36f00668ad1af9e5c02acd1397/raw/f8a271180ed8e5a307fd6c6f2bfbf18c9f30b916/install.sh"
+  url_chainloop_cli="https://docs.chainloop.dev/install.sh"
   if [ -n "${CHAINLOOP_VERSION}" ]; then
     curl -sfL "${url_chainloop_cli}" | bash -s -- --version v${CHAINLOOP_VERSION} --path $CHAINLOOP_BIN_PATH
   else

--- a/tools/src/lib/chainloop.sh
+++ b/tools/src/lib/chainloop.sh
@@ -33,7 +33,7 @@ chainloop_bin_install() {
 install_chainloop_cli() {
   mkdir -p ${CHAINLOOP_TMP_DIR} $CHAINLOOP_BIN_PATH
   log "Installing Chainloop CLI"
-  url_chainloop_cli="https://raw.githubusercontent.com/chainloop-dev/chainloop/eb53f4e8ce3c35251553efc77b7e04e792b2c992/docs/static/install.sh"
+  url_chainloop_cli="https://docs.chainloop.dev/install.sh"
   if [ -n "${CHAINLOOP_VERSION}" ]; then
     curl -sfL "${url_chainloop_cli}" | bash -s -- --version v${CHAINLOOP_VERSION} --path $CHAINLOOP_BIN_PATH
   else

--- a/tools/src/lib/chainloop.sh
+++ b/tools/src/lib/chainloop.sh
@@ -33,7 +33,7 @@ chainloop_bin_install() {
 install_chainloop_cli() {
   mkdir -p ${CHAINLOOP_TMP_DIR} $CHAINLOOP_BIN_PATH
   log "Installing Chainloop CLI"
-  url_chainloop_cli="https://docs.chainloop.dev/install.sh"
+  url_chainloop_cli="https://gist.githubusercontent.com/javirln/01cfcb36f00668ad1af9e5c02acd1397/raw/f8a271180ed8e5a307fd6c6f2bfbf18c9f30b916/install.sh"
   if [ -n "${CHAINLOOP_VERSION}" ]; then
     curl -sfL "${url_chainloop_cli}" | bash -s -- --version v${CHAINLOOP_VERSION} --path $CHAINLOOP_BIN_PATH
   else

--- a/tools/test/test.bats
+++ b/tools/test/test.bats
@@ -62,8 +62,8 @@ setup() {
 
 # Abats test_tags=bats:focus
 @test "full attestation flow" {
-    export CHAINLOOP_WORKFLOW_NAME="chainloop-labs-tests"
-    export CHAINLOOP_PROJECT_NAME="chainloop"
+    export CHAINLOOP_WORKFLOW_NAME="labs-tests"
+    export CHAINLOOP_PROJECT_NAME="labs"
     cp ./c8l /tmp
     cd /tmp
     mkdir -p .c8l_cache


### PR DESCRIPTION
This patch modifies the URL where the Chainloop's CLI is being downloaded from to point to docs.chainloop.dev.

Had to modify the integration tests to point to a new workflow and project. I've regenerated the API Token as well.

Ref: PFM-2843